### PR TITLE
Fix profile metrics units and clarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "2.0.1",
 			"license": "ISC",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.12.1",
-				"@tago-io/sdk": "^11.3.9",
+				"@modelcontextprotocol/sdk": "^1.17.0",
+				"@tago-io/sdk": "^12.0.3",
 				"dotenv": "^16.5.0",
 				"mcps-logger": "^1.0.0",
 				"shx": "^0.4.0",
@@ -719,9 +719,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
-			"integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.0.tgz",
+			"integrity": "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.6",
@@ -729,6 +729,7 @@
 				"cors": "^2.8.5",
 				"cross-spawn": "^7.0.5",
 				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
 				"pkce-challenge": "^5.0.0",
@@ -1091,12 +1092,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@socket.io/component-emitter": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-			"license": "MIT"
-		},
 		"node_modules/@swc/core": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.0.tgz",
@@ -1337,35 +1332,20 @@
 			}
 		},
 		"node_modules/@tago-io/sdk": {
-			"version": "11.3.10",
-			"resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-11.3.10.tgz",
-			"integrity": "sha512-7bHNf+8FeQhqmW4iO6t2R8cZDhB8rhl/pmF9xxpbVt15+pz+lOFpQdNGhtUG+45Q6yW7V42ayIgfWIo5V8omTA==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-12.0.3.tgz",
+			"integrity": "sha512-GqWGNYUNOtM9eoLyx2b9naO89+HQ/jpLCzSQsAvt4Kj/24MVB0F8yT/hdmK62ZdUxhn8vTkSvNbnoDmwltk/Ow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"axios": "1.7.4",
-				"form-data": "4.0.0",
-				"nanoid": "3.3.7",
-				"papaparse": "5.4.1",
-				"qs": "6.12.0",
-				"socket.io-client": "4.7.5"
+				"nanoid": "3.3.11",
+				"papaparse": "5.5.3",
+				"qs": "6.14.0"
 			},
 			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=6.0.0"
+				"node": ">=20.0.0"
 			},
 			"optionalDependencies": {
 				"eventsource": "4.0.0"
-			}
-		},
-		"node_modules/@tago-io/sdk/node_modules/axios": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/@tago-io/sdk/node_modules/eventsource": {
@@ -1379,39 +1359,6 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@tago-io/sdk/node_modules/nanoid": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/@tago-io/sdk/node_modules/qs": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-			"integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -1707,12 +1654,6 @@
 			"engines": {
 				"node": ">=12"
 			}
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib": {
 			"version": "2.200.1",
@@ -2269,18 +2210,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2395,15 +2324,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2481,45 +2401,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io-client": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-			"integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.17.1",
-				"xmlhttprequest-ssl": "~2.0.0"
-			}
-		},
-		"node_modules/engine.io-client/node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/engine.io-parser": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-			"integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -2859,61 +2740,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/form-data/node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/form-data/node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -3410,7 +3236,6 @@
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
 			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3523,9 +3348,9 @@
 			}
 		},
 		"node_modules/papaparse": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-			"integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+			"integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
 			"license": "MIT"
 		},
 		"node_modules/parseurl": {
@@ -3657,12 +3482,6 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
 		},
 		"node_modules/pump": {
 			"version": "3.0.2",
@@ -4104,68 +3923,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC"
-		},
-		"node_modules/socket.io-client": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
-			"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.2",
-				"engine.io-client": "~6.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/socket.io-client/node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/socket.io-parser": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.1"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/socket.io-parser/node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
@@ -4855,35 +4612,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC"
-		},
-		"node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xmlhttprequest-ssl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-			"engines": {
-				"node": ">=0.4.0"
-			}
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tago-io/mcp-server",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tago-io/mcp-server",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "ISC",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
 		"vitest": "^3.1.4"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.12.1",
-		"@tago-io/sdk": "^11.3.9",
+		"@modelcontextprotocol/sdk": "^1.17.0",
+		"@tago-io/sdk": "^12.0.3",
 		"dotenv": "^16.5.0",
 		"mcps-logger": "^1.0.0",
 		"shx": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tago-io/mcp-server",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"main": "build/index.js",
 	"bin": {
 		"tago-mcp-server": "build/index.js"

--- a/src/services/profile/tools/profile-metrics.ts
+++ b/src/services/profile/tools/profile-metrics.ts
@@ -42,6 +42,7 @@ async function profileMetricsTool(resources: Resources, params: ProfileMetricsSc
       return { resource: key, used: usedLimit, limit };
     });
 
+    // TODO: Must get the resources limits when the SDK is updated to include the /limits endpoint
     data = { limits: tabularFormat, resources_amount: rawLimits.amount };
   }
 
@@ -73,7 +74,7 @@ All the metrics below are montlhy usages, and resets every month.
 Data Input: Amount of registers received
 Data Output: Amount of registers read
 Data Storage: Amount of registers used
-Analysis: Minutes spents
+Analysis Run: Analysis Run Minutes spents.
 E-mails / SMS / Push Notification: Number of messages sent`;
 
   return markdownResponse;

--- a/src/services/profile/tools/profile-metrics.ts
+++ b/src/services/profile/tools/profile-metrics.ts
@@ -1,9 +1,9 @@
-import { z } from "zod/v3";
 import { Resources } from "@tago-io/sdk";
+import { z } from "zod/v3";
 
-import { IDeviceToolConfig } from "../../types";
-import { convertJSONToMarkdown } from "../../../utils/markdown";
 import { getProfileID } from "../../../utils/get-profile-id";
+import { convertJSONToMarkdown } from "../../../utils/markdown";
+import { IDeviceToolConfig } from "../../types";
 
 const profileMetricsSchema = z.object({
   type: z
@@ -56,7 +56,17 @@ async function profileMetricsTool(resources: Resources, params: ProfileMetricsSc
     });
   }
 
-  const markdownResponse = convertJSONToMarkdown(data);
+  let markdownResponse = convertJSONToMarkdown(data);
+
+  markdownResponse += `\n\n# Units\n
+Data Input: Amount of registers received
+Data Output: Amount of registers read
+Data Storage: Amount of registers used
+Analysis: Minutes spents
+E-mails / SMS / Push Notification: Number of messages sent
+Run Users: Number of users
+File Storage: Megabytes used
+  `;
 
   return markdownResponse;
 }


### PR DESCRIPTION
## Problem
The profile-metrics tool was returning raw data without context about measurement units or clear formatting, making it difficult for users to understand what the metrics represent and their time-based nature.

## Investigation
- Profile metrics lacked unit information for monthly usage data
- Raw limits data wasn't presented in a user-friendly tabular format
- Description formatting could be improved for better readability

## Solution
- Added comprehensive units section explaining all metric types (Data Input/Output/Storage, Analysis minutes, message counts)
- Transformed raw limits data into tabular format showing resource, used, and limit columns
- Enhanced description formatting with better line breaks and structure
- Clarified that all metrics are monthly usage values that reset each month

```markdown
### limits:

| resource | limit | used |
| --- | --- | --- |
| analysis | 100 | 0 |
| data_records | 100000 | 182 |
| email | 20 | 0 |
| input | 200 | 20 |
| output | 2000 | 609 |
| sms | 5 | 0 |
| run_users | 10 | 5 |
| push_notification | 15 | 0 |
| file_storage | 20 | 111.18 |
| tcore | 1 | 0 |

### resources_amount:

| Key | Value |
| --- | ----- |
| device | 12 |
| bucket | 12 |
| dashboard | 26 |
| analysis | 22 |
| action | 9 |
| am | 16 |
| run_users | 5 |
| dictionary | 24 |
| connectors | 4 |
| networks | 1 |
| tcore | 0 |


# Units


All the metrics below are montlhy usages, and resets every month.
Data Input: Amount of registers received
Data Output: Amount of registers read
Data Storage: Amount of registers used
Analysis: Minutes spents
E-mails / SMS / Push Notification: Number of messages sent
```